### PR TITLE
Remove deprecated mysql authentication plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Web project [![Remove this later](https://img.shields.io/badge/-template-green)](https://digital-ateam.de/)
+# Web project [![Remove this later](https://img.shields.io/badge/-template-green)](https://webmedia20.de/)
 This is a template for a simple web server Docker setup with a database, PHP, Nginx and PhpMyAdmin (but you can also use e.g. Adminer). This is for development purposes only! Here you should insert a brief description of your project.
 
 ## Requirements
@@ -13,7 +13,7 @@ This is a template for a simple web server Docker setup with a database, PHP, Ng
 </details>
 
 <details>
-<summary>macOS High Sierra to Monterey (& M1)</summary>
+<summary>macOS High Sierra to Sonoma (& M1 or higher)</summary>
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 - [Git](https://github.com/git-guides/install-git#install-git-on-mac)

--- a/app/index.php
+++ b/app/index.php
@@ -24,6 +24,6 @@
         echo 'PHP connected successfully to DB';
     ?>
     </p>
-    <sub>Made by Webmedia 2.0 in Karlsruhe</sub>
+    <sub>Made by mau & Webmedia 2.0 in Karlsruhe</sub>
 </body>
 </html>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
         ports:
             - 3306:3306
         command:
-            --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci 
-            --default-authentication-plugin=mysql_native_password
+            --character-set-server=utf8mb4
+            --collation-server=utf8mb4_unicode_ci
             --init-file /docker-entrypoint-initdb.d/init.sql
         volumes:
             - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
         environment:
             MYSQL_ROOT_USER: root
             MYSQL_ROOT_PASSWORD: root
-            MYSQL_DATABASE: wm
+            MYSQL_DATABASE: wmdb
             MYSQL_USER: user1
             MYSQL_PASSWORD: user1
         networks:


### PR DESCRIPTION
### Changes Made:
- Removed deprecated `--default-authentication-plugin=mysql_native_password` option from MySQL `db` service in Docker Compose file.
- Updated configuration to align with MySQL's default authentication plugin `caching_sha2_password`.
- Improvements on README.md and Author naming

### Details:
In the MySQL versions (8.0 and later), the `--default-authentication-plugin=mysql_native_password` option has been deprecated and removed. This pull request updates the Docker Compose configuration for the MySQL service (`db`) to remove this deprecated option.

### Why This Change?
- **Compatibility:** Ensures compatibility with newer MySQL versions where `mysql_native_password` is no longer supported as the default authentication plugin.
- **Security:** Aligns with MySQL best practices by using `caching_sha2_password`, which offers stronger security mechanisms compared to `mysql_native_password`.

### Steps Taken:
- Modified the `db` service definition in the Docker Compose file (`docker-compose.yml`) to remove `--default-authentication-plugin=mysql_native_password` from the `command` section.
- Verified connectivity and functionality post-update to ensure no authentication issues arise with applications connecting to MySQL.

This update ensures that our Dockerized MySQL environment remains secure and compatible with modern MySQL standards.
